### PR TITLE
Fix for validates_uniqueness_of when scope(s) are defined

### DIFF
--- a/lib/database_validation.rb
+++ b/lib/database_validation.rb
@@ -35,7 +35,7 @@ module DatabaseValidation
       end
       ActiveRecord::Base.connection.indexes(base.table_name).each do |key|
         col_syms = key.columns.map(&:to_sym)
-        base.send(:validates_uniqueness_of, col_syms.first.to_sym, :scope => col_syms.slice(1, -1)) if key.unique
+        base.send(:validates_uniqueness_of, col_syms.first.to_sym, :scope => col_syms[1..-1]) if key.unique
       end
     end
 


### PR DESCRIPTION
When indexes have multiple columns and scope(s) are required.
